### PR TITLE
ODP-4784 - KUDU-3491 Destruct master before creating a new one

### DIFF
--- a/src/kudu/master/master_runner.cc
+++ b/src/kudu/master/master_runner.cc
@@ -455,6 +455,7 @@ Status RunMasterServer() {
     // If we succeeded, wipe the system catalog on this node and initiate a
     // copy from another node.
     RETURN_NOT_OK(ClearLocalSystemCatalogAndCopy(leader_hp));
+    server.reset();
     server.reset(new Master(opts));
     RETURN_NOT_OK(server->Init());
     RETURN_NOT_OK(server->Start());


### PR DESCRIPTION
ServerBase constructor runs MinidumpExceptionHandler constructor that calls RegisterMinidumpExceptionHandler(). This function increments the static atomic variable current_num_instances_. Then the ServerBase is destructed, a similar process happens and current_num_instances_ gets decremented. If current_num_instances_ is not zero before incrementing or not 1 before decrementing, then it is considered an error. This indicates that only one Server can run at any given time. But in case of multi-master config, the master server is replaced, and without the change it is possible that the second server's constructor precede first server's destructor. This change makes it sure that the destructor is executed before the second one's constructor.

Change-Id: I3c1019d092bbf9e58f4fc33753a1218bc79735d3
Reviewed-on: http://gerrit.cloudera.org:8080/20913
Reviewed-by: Attila Bukor <abukor@apache.org>
Reviewed-by: Mahesh Reddy <mreddy@cloudera.com>
Tested-by: Kudu Jenkins