### PR TITLE
WIP: Upgrade to Spark3.5.5

### DIFF
--- a/java/kudu-backup/build.gradle
+++ b/java/kudu-backup/build.gradle
@@ -50,21 +50,40 @@ dependencies {
   testImplementation libs.log4jSlf4jImpl
   testImplementation libs.scalatest
   testImplementation libs.logCaptor
+
+  // Have to re-define some dependencies here, as compile-only dependencies
+  // are not inherited by the test classpath.
+  // See: https://blog.gradle.org/introducing-compile-only-dependencies
+  // Note: compileUnshaded is extended from the compileOnly dependency scope.
+  testImplementation libs.scalaLibrary
+  testImplementation(libs.sparkAvro) {
+    exclude group: "org.apache.logging.log4j"
+  }
+  testImplementation( libs.sparkCore) {
+    exclude group: "org.apache.logging.log4j"
+  }
+  testImplementation(libs.sparkSql) {
+    exclude group: "org.apache.logging.log4j"
+  }
+  testImplementation libs.slf4jApi
 }
 
 shadowJar {
   dependencies {
     exclude(dependency(libs.jsr305))
-    exclude(dependency("log4j:log4j:.*"))
+    exclude(dependency("log4j:log4j::.*"))
+    exclude(dependency("com.fasterxml.jackson.core::.*"))
     exclude(dependency("org.apache.arrow::.*"))
     exclude(dependency("org.apache.avro::.*"))
     exclude(dependency("org.apache.curator::.*"))
     exclude(dependency("org.apache.hadoop::.*"))
     exclude(dependency("org.apache.ivy:ivy::.*"))
-    exclude(dependency("org.apache.parquet:.*"))
+    exclude(dependency("org.apache.logging.log4j::.*"))
+    exclude(dependency("org.apache.parquet::.*"))
     exclude(dependency("org.apache.spark::.*"))
     exclude(dependency("org.codehaus.janino::.*"))
     exclude(dependency("org.glassfish.jersey.core::.*"))
+    exclude(dependency("joda-time::.*"))
     exclude(dependency("org.scala-lang::.*"))
     exclude(dependency("org.xerial.snappy::.*"))
   }
@@ -75,9 +94,11 @@ shadowJar {
   exclude '**/*.html'
   exclude '**/*.md'
   exclude 'META-INF/services/**'
-  exclude 'META-INF/versions/11/org/roaringbitmap/**'
   exclude 'codegen/**'
   exclude 'assets/**'
+  exclude 'org/threeten/**'
+  exclude 'org/apache/arrow/**'
+  exclude 'org/apache/orc/**'
   exclude 'javax/**'
   exclude 'org/jetbrains/**'
 

--- a/java/kudu-spark-tools/build.gradle
+++ b/java/kudu-spark-tools/build.gradle
@@ -58,6 +58,7 @@ shadowJar {
     exclude(dependency("org.apache.spark::.*"))
     exclude(dependency("org.codehaus.janino::.*"))
     exclude(dependency("org.glassfish.jersey.core::.*"))
+    exclude(dependency("joda-time::.*"))
     exclude(dependency("org.scala-lang::.*"))
     exclude(dependency("org.xerial.snappy::.*"))
   }
@@ -68,9 +69,11 @@ shadowJar {
   exclude '**/*.html'
   exclude '**/*.md'
   exclude 'META-INF/services/**'
-  exclude 'META-INF/versions/11/org/roaringbitmap/**'
   exclude 'codegen/**'
   exclude 'javax/**'
+  exclude 'org/threeten/**'
+  exclude 'org/apache/arrow/**'
+  exclude 'org/apache/orc/**'
   exclude 'org/jetbrains/**'
 
   minimize()

--- a/java/kudu-spark/build.gradle
+++ b/java/kudu-spark/build.gradle
@@ -63,10 +63,13 @@ shadowJar {
   exclude '**/*.html'
   exclude '**/*.md'
   exclude 'META-INF/services/**'
-  exclude 'META-INF/versions/11/org/roaringbitmap/**'
   exclude 'codegen/**'
+  exclude 'org/threeten/**'
+  exclude 'org/apache/arrow/**'
+  exclude 'org/apache/orc/**'
   exclude 'javax/**'
   exclude 'org/jetbrains/**'
+  exclude 'org/joda/time/tz/**'
 
   minimize()
 }

--- a/java/kudu-spark/src/main/scala/org/apache/kudu/spark/kudu/KuduContext.scala
+++ b/java/kudu-spark/src/main/scala/org/apache/kudu/spark/kudu/KuduContext.scala
@@ -29,7 +29,6 @@ import org.apache.hadoop.util.ShutdownHookManager
 import org.apache.spark.Partitioner
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
-import org.apache.spark.unsafe.types.ByteArray
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.DataType
@@ -445,6 +444,19 @@ class KuduContext(
     log.info(s"completed $operation ops: duration histogram: $durationHistogram")
   }
 
+  // This method is copied from Spark code as it's moved from TypeUtils to
+  // ByteArray between Spark 3.2 and 3.3
+  private def compareBinary(x: Array[Byte], y: Array[Byte]): Int = {
+    val limit = if (x.length <= y.length) x.length else y.length
+    var i = 0
+    while (i < limit) {
+      val res = (x(i) & 0xff) - (y(i) & 0xff)
+      if (res != 0) return res
+      i += 1
+    }
+    x.length - y.length
+  }
+
   private[spark] def repartitionRows(
       rdd: RDD[Row],
       tableName: String,
@@ -475,7 +487,7 @@ class KuduContext(
     // to enable rdd sorting functions below.
     implicit val byteArrayOrdering: Ordering[Array[Byte]] = new Ordering[Array[Byte]] {
       def compare(x: Array[Byte], y: Array[Byte]): Int = {
-        ByteArray.compareBinary(x, y)
+        compareBinary(x, y)
       }
     }
 


### PR DESCRIPTION
Currently does not compile because of missing Acceldata dependencies.

Upgrading Spark dependency from 3.2.4 to 3.5.5, also as an addition log4j was also updated from 2.17.1 to 2.20.0 for compatibility reasons.

The compareBinary method was copied from the Spark code as it's moved from TypeUtils to ByteArray between Spark 3.2 and 3.3.

Change-Id: I341d84f7a7b32a26b8d9699b929cce1252d0ebad
Reviewed-on: http://gerrit.cloudera.org:8080/22604
Tested-by: Kudu Jenkins
Reviewed-by: Marton Greber <greber.mx@gmail.com>
Reviewed-by: Gabriella Lotz <lotzgabriella@gmail.com>
Reviewed-by: Attila Bukor <abukor@apache.org>