### PR TITLE
ODP-6342 : Bump Netty version to 4.1.132.Final

### DIFF
--- a/java/gradle/dependencies.gradle
+++ b/java/gradle/dependencies.gradle
@@ -51,7 +51,7 @@ versions += [
     micrometer     : "1.8.2",
     mockito        : "4.2.0",
     murmur         : "1.0.0",
-    netty          : "4.1.130.Final",
+    netty          : "4.1.132.Final",
     osdetector     : "1.6.2",
     protobuf       : "3.25.5",
     ranger         : "2.5.0.3.2.3.6-2",


### PR DESCRIPTION
This patch was tested locally.