### PR TITLE
ODP-7101: Fix gradle capability conflict for lz4-java dependency

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -80,6 +80,20 @@ subprojects {
       force "com.google.protobuf:protobuf-java:$versions.protobuf"
       force "io.airlift:aircompressor:$versions.aircompressor"
       force "dnsjava:dnsjava:$versions.dnsjava"
+
+      // Resolve org.lz4:lz4-java -> at.yawk.lz4:lz4-java capability conflict.
+      // Sonatype relocated org.lz4:lz4-java:1.8.1 to at.yawk.lz4:lz4-java:1.8.1
+      // as part of the CVE-2025-12183 fix; both declare the same Gradle
+      // capability, which Gradle can't auto-resolve (gradle/gradle#35916).
+      capabilitiesResolution {
+        withCapability("org.lz4:lz4-java") {
+          def toBeSelected = candidates.find { it.id.toString().startsWith("at.yawk.lz4") }
+          if (toBeSelected != null) {
+            select(toBeSelected)
+            because("org.lz4:lz4-java:1.8.1 relocation to at.yawk.lz4 per CVE-2025-12183")
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Sonatype relocated org.lz4:lz4-java:1.8.1 to at.yawk.lz4:lz4-java:1.8.1 as part of the CVE-2025-12183 fix. Both artifacts declare the same Gradle capability, which Gradle's dependency resolution engine cannot auto-resolve (gradle/gradle#35916), causing kudu-spark:shadowJar to fail with:

  Cannot select module with conflict on capability
  'org.lz4:lz4-java:1.8.1' also provided by [...]

lz4-java is pulled in transitively via spark-core (kudu-spark -> org.apache.spark:spark-core_2.12:3.5.5.3.2.3.7-2 -> org.lz4:lz4-java).

Add an explicit capabilitiesResolution rule to select the at.yawk.lz4 artifact, resolving the conflict.