### PR TITLE
OSV-21414 - CVE - Bumped-up Netty4 to 4.1.135.Final to address CVE-2026-42578

### DIFF
--- a/java/gradle/dependencies.gradle
+++ b/java/gradle/dependencies.gradle
@@ -51,7 +51,7 @@ versions += [
     micrometer     : "1.8.2",
     mockito        : "4.2.0",
     murmur         : "1.0.0",
-    netty          : "4.1.132.Final",
+    netty          : "4.1.135.Final",
     osdetector     : "1.6.2",
     protobuf       : "3.25.5",
     ranger         : "2.5.0.3.3.6.5-SNAPSHOT",


### PR DESCRIPTION
- Component: kudu (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: Netty4 → 4.1.135.Final
- Tickets: OSV-21414
- Advisories: CVE-2026-42578
- Files: java/gradle/dependencies.gradle