### PR TITLE
OSV-21416 - CVE - Bumped-up commons-compress to 1.26.0 to address CVE-2024-25710/CVE-2024-26308

### DIFF
--- a/ext/ranger/install/lib/gradle.properties
+++ b/ext/ranger/install/lib/gradle.properties
@@ -1,6 +1,6 @@
 commonscliVersion=1.2
 commonscollectionsVersion=3.2.2
-commonscompressVersion=1.21
+commonscompressVersion=1.26.0
 commonsconfigurationVersion=2.10.1
 commonslangVersion=3.3.2
 commonsloggingVersion=1.2


### PR DESCRIPTION
- Component: kudu (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: commons-compress → 1.26.0
- Tickets: OSV-21416, OSV-21417
- Advisories: CVE-2024-25710, CVE-2024-26308
- Files: ext/ranger/install/lib/gradle.properties